### PR TITLE
Add parser for NoRel logs and change timelines return signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Additionally, there is a [Gurobi TechTalk demonstrating how to use grblogtools (
     glt.plot(timelines['nodelog'], y="Gap", color="Log", type="line")
     ```
 
-    - progress of the norel heuristic:
+    - progress of the norel heuristic (note, the time recorded here is since the start of norel, and does not include presolve + read time):
     ```Python
-    glt.plot(timelines['norel'], x="NoRelTime", y="Incumbent", color="Log", type="line")
+    glt.plot(timelines['norel'], x="Time", y="Incumbent", color="Log", type="line")
     ```
 
     These are just examples using the [Plotly Python library](https://plotly.com/python/) - of course, any other plotting library of your choice can be used to work with these DataFrames.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Additionally, there is a [Gurobi TechTalk demonstrating how to use grblogtools (
     ```Python
     import grblogtools as glt
 
-    summary, timelines, rootlp = glt.get_dataframe(["run1/*.log", "run2/*.log"], timelines=True)
+    summary, timelines = glt.get_dataframe(["run1/*.log", "run2/*.log"], timelines=True)
     ```
     Depending on your requirements, you may need to filter or modify the resulting DataFrames.
 
@@ -43,7 +43,12 @@ Additionally, there is a [Gurobi TechTalk demonstrating how to use grblogtools (
     
     - progress charts for the individual runs:
     ```Python
-    glt.plot(timelines, y="Gap", color="Log", type="line")
+    glt.plot(timelines['nodelog'], y="Gap", color="Log", type="line")
+    ```
+
+    - progress of the norel heuristic:
+    ```Python
+    glt.plot(timelines['norel'], x="NoRelTime", y="Incumbent", color="Log", type="line")
     ```
 
     These are just examples using the [Plotly Python library](https://plotly.com/python/) - of course, any other plotting library of your choice can be used to work with these DataFrames.

--- a/data/912-NoRelHeurWork60-glass4-0.log
+++ b/data/912-NoRelHeurWork60-glass4-0.log
@@ -1,0 +1,97 @@
+Gurobi 9.1.2 (mac64, gurobi_cl) logging started Tue Oct  5 09:11:51 2021
+
+Set parameter NoRelHeurWork to value 60
+Set parameter LogFile to value 912-NoRelHeurWork60-glass4-0.log
+
+Gurobi Optimizer version 9.1.2 build v9.1.2rc0 (mac64)
+Copyright (c) 2021, Gurobi Optimization, LLC
+
+Read MPS format model from file /data/glass4.mps
+Reading time = 0.00 seconds
+glass4: 396 rows, 322 columns, 1815 nonzeros
+Thread count: 4 physical cores, 8 logical processors, using up to 8 threads
+Optimize a model with 396 rows, 322 columns and 1815 nonzeros
+Model fingerprint: 0x18b19fdf
+Variable types: 20 continuous, 302 integer (0 binary)
+Coefficient statistics:
+  Matrix range     [1e+00, 8e+06]
+  Objective range  [1e+00, 1e+06]
+  Bounds range     [1e+00, 8e+02]
+  RHS range        [1e+00, 8e+06]
+Presolve removed 6 rows and 6 columns
+Presolve time: 0.01s
+Presolved: 390 rows, 316 columns, 1803 nonzeros
+Variable types: 19 continuous, 297 integer (297 binary)
+Found heuristic solution: objective 3.133356e+09
+Starting NoRel heuristic
+Elapsed time for NoRel heuristic: 5s
+Found heuristic solution: objective 3.033354e+09
+Found heuristic solution: objective 2.633356e+09
+Found heuristic solution: objective 2.633356e+09
+Found heuristic solution: objective 2.633355e+09
+Found heuristic solution: objective 2.533354e+09
+Found heuristic solution: objective 2.533354e+09
+Found heuristic solution: objective 2.533353e+09
+Found heuristic solution: objective 2.050019e+09
+Found heuristic solution: objective 2.000015e+09
+Found heuristic solution: objective 2.000015e+09
+Found heuristic solution: objective 1.933348e+09
+Found heuristic solution: objective 1.900014e+09
+Found heuristic solution: objective 1.811125e+09
+Found heuristic solution: objective 1.800014e+09
+Found heuristic solution: objective 1.788902e+09
+Found heuristic solution: objective 1.766680e+09
+Found heuristic solution: objective 1.750016e+09
+Found heuristic solution: objective 1.680015e+09
+Found heuristic solution: objective 1.600014e+09
+Found heuristic solution: objective 1.600014e+09
+Found heuristic solution: objective 1.600014e+09
+Found heuristic solution: objective 1.600014e+09
+Found heuristic solution: objective 1.600013e+09
+Found heuristic solution: objective 1.525013e+09
+Found heuristic solution: objective 1.525013e+09
+Found heuristic solution: objective 1.525013e+09
+Found heuristic solution: objective 1.500013e+09
+Found heuristic solution: objective 1.450014e+09
+Elapsed time for NoRel heuristic: 10s (best bound 8.00002e+08)
+Found heuristic solution: objective 1.400013e+09
+Elapsed time for NoRel heuristic: 16s (best bound 8.00002e+08)
+Found heuristic solution: objective 1.200013e+09
+Elapsed time for NoRel heuristic: 21s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 27s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 32s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 39s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 46s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 51s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 57s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 62s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 67s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 72s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 79s (best bound 8.00002e+08)
+Elapsed time for NoRel heuristic: 93s (best bound 8.00002e+08)
+
+Root simplex log...
+
+Iteration    Objective       Primal Inf.    Dual Inf.      Time
+       0    8.0000240e+08   1.843200e+04   0.000000e+00     93s
+      72    8.0000240e+08   0.000000e+00   0.000000e+00     93s
+
+Root relaxation: objective 8.000024e+08, 72 iterations, 0.00 seconds
+
+    Nodes    |    Current Node    |     Objective Bounds      |     Work
+ Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time
+
+     0     0 8.0000e+08    0   72 1.2000e+09 8.0000e+08  33.3%     -   92s
+     0     0 8.0000e+08    0   72 1.2000e+09 8.0000e+08  33.3%     -   92s
+     0     0 8.0000e+08    0   72 1.2000e+09 8.0000e+08  33.3%     -   92s
+     0     0 8.0000e+08    0   80 1.2000e+09 8.0000e+08  33.3%     -   92s
+     0     0 8.0000e+08    0   76 1.2000e+09 8.0000e+08  33.3%     -   92s
+     0     2 8.0000e+08    0   75 1.2000e+09 8.0000e+08  33.3%     -   92s
+
+Explored 5135 nodes (36786 simplex iterations) in 93.70 seconds
+Thread count was 8 (of 8 available processors)
+
+Solution count 10: 1.20001e+09 1.40001e+09 1.45001e+09 ... 1.60001e+09
+
+Optimal solution found (tolerance 1.00e-04)
+Best objective 1.200012600000e+09, best bound 1.200006450000e+09, gap 0.0005%

--- a/src/grblogtools/grblogtools.py
+++ b/src/grblogtools/grblogtools.py
@@ -450,6 +450,41 @@ def get_log_info(loglines, verbose=False):
             if result:
                 values["Cuts: " + result["Name"].strip()] = int(result["Count"])
 
+    # NoRel log
+    norel_log_start = re.compile("Starting NoRel heuristic")
+    norel_first_line, result = _regex_first_match(
+        loglines, [norel_log_start], reverse=False
+    )
+    if norel_first_line and norel_first_line < len(loglines) - 1:
+        norel_last_line = _get_last_nonempty_line(loglines, norel_first_line + 1)
+        norel_primal_regex = re.compile(
+            "Found heuristic solution:\sobjective\s(?P<Incumbent>[^\s]+)"
+        )
+        norel_elapsed_time = re.compile(
+            "Elapsed time for NoRel heuristic:\s(?P<NoRelTime>\d+)s"
+        )
+        norel_elapsed_bound = re.compile(
+            "Elapsed time for NoRel heuristic:\s(?P<NoRelTime>\d+)s\s\(best\sbound\s(?P<BestBd>[^\s]+)\)"
+        )
+        norel_log = []
+        norel_incumbent = {}
+        for norel_log_line in loglines[
+            norel_first_line + 1 : norel_last_line + 1
+        ]:
+            # NoRel shows the solutions and timings/bounds on different lines, so
+            # when we see a timing line, we store the most recent incumbent there,
+            # instead of recording the primal when the log line is found.
+            result = norel_primal_regex.match(norel_log_line)
+            if result:
+                norel_incumbent = result.groupdict()
+            result = norel_elapsed_bound.match(norel_log_line) or norel_elapsed_time.match(norel_log_line)
+            if result:
+                tmp = result.groupdict()
+                tmp.update(norel_incumbent)
+                norel_log.append(tmp)
+        if len(norel_log) > 0:
+            values["NoRelLog"] = norel_log
+
     # Simplex Log (can be regular LP, root node or crossover)
     simplex_log_start = re.compile(
         "Iteration(\s+)Objective(\s+)Primal Inf.(\s+)Dual Inf.(\s+)Time"
@@ -737,6 +772,20 @@ def get_dataframe(logfiles, timelines=False, verbose=False, merged_logs=False):
     summary = summary.replace("-", nan)
 
     if timelines:
+
+        # collect norel log
+        norel = pd.DataFrame()
+        for log_info in log_infos:
+            log = log_info.get("LogFilePath")
+            final = summary[summary["LogFilePath"] == log]
+            nrlines = log_info.get("NoRelLog")
+            if nrlines is not None:
+                norel_ = pd.DataFrame(nrlines).apply(
+                    pd.to_numeric, errors="coerce"
+                )
+                _copy_keys(final, norel_)
+                norel = norel.append(norel_, ignore_index=True)
+
         # collect root LP log
         rootlp = pd.DataFrame()
         for log_info in log_infos:
@@ -791,7 +840,7 @@ def get_dataframe(logfiles, timelines=False, verbose=False, merged_logs=False):
 
                 tl = tl.append(tl_, ignore_index=True)
 
-        return summary, tl, rootlp
+        return summary, dict(nodelog=tl, rootlp=rootlp, norel=norel)
     else:
         return summary
 

--- a/src/grblogtools/grblogtools.py
+++ b/src/grblogtools/grblogtools.py
@@ -461,10 +461,10 @@ def get_log_info(loglines, verbose=False):
             "Found heuristic solution:\sobjective\s(?P<Incumbent>[^\s]+)"
         )
         norel_elapsed_time = re.compile(
-            "Elapsed time for NoRel heuristic:\s(?P<NoRelTime>\d+)s"
+            "Elapsed time for NoRel heuristic:\s(?P<Time>\d+)s"
         )
         norel_elapsed_bound = re.compile(
-            "Elapsed time for NoRel heuristic:\s(?P<NoRelTime>\d+)s\s\(best\sbound\s(?P<BestBd>[^\s]+)\)"
+            "Elapsed time for NoRel heuristic:\s(?P<Time>\d+)s\s\(best\sbound\s(?P<BestBd>[^\s]+)\)"
         )
         norel_log = []
         norel_incumbent = {}

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,3 +1,4 @@
+from datetime import time
 import grblogtools as glt
 
 
@@ -8,4 +9,24 @@ def test_get_dataframe():
 
 def test_read_with_timelines():
     """Check timelines argument."""
-    summary, timelines, rootlp = glt.get_dataframe(["data/*.log"], timelines=True)
+    summary, timelines = glt.get_dataframe(["data/*.log"], timelines=True)
+    assert set(timelines.keys()) == {"norel", "rootlp", "nodelog"}
+
+
+def test_norel_timeline():
+    """ Check norel logs before the root node. Note that this reports norel's
+    clock, so read + presolve time would need to be added for 'real' time. """
+    summary, timelines = glt.get_dataframe(
+        ["data/912-NoRelHeurWork60-glass4-0.log"], timelines=True,
+    )
+    norel = timelines['norel']
+    assert norel.shape[0] == 15
+    assert norel["Log"].unique()[0] == "912-NoRelHeurWork60"
+    assert norel["NoRelTime"].min() == 5.0
+    assert norel["NoRelTime"].max() == 93.0
+    assert (norel["Incumbent"].max() - 1.450014e+09) <= 1e+05
+    assert (norel["Incumbent"].min() - 1.2000e+09) <= 1e+05
+    assert (norel["BestBd"].max() - 8.00002e+08) <= 1e+05
+    assert (norel["BestBd"].min() - 8.00002e+08) <= 1e+05
+    # Sometimes a bound isn't reported.
+    assert norel["BestBd"].isnull().sum() == 1

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -22,8 +22,8 @@ def test_norel_timeline():
     norel = timelines['norel']
     assert norel.shape[0] == 15
     assert norel["Log"].unique()[0] == "912-NoRelHeurWork60"
-    assert norel["NoRelTime"].min() == 5.0
-    assert norel["NoRelTime"].max() == 93.0
+    assert norel["Time"].min() == 5.0
+    assert norel["Time"].max() == 93.0
     assert (norel["Incumbent"].max() - 1.450014e+09) <= 1e+05
     assert (norel["Incumbent"].min() - 1.2000e+09) <= 1e+05
     assert (norel["BestBd"].max() - 8.00002e+08) <= 1e+05

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,11 @@
+import grblogtools as glt
+
+
+def test_get_dataframe():
+    """Just check we read without errors."""
+    summary = glt.get_dataframe(["data/*.log"])
+
+
+def test_read_with_timelines():
+    """Check timelines argument."""
+    summary, timelines, rootlp = glt.get_dataframe(["data/*.log"], timelines=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36,py37,py38,py39
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
* Adds another timeline dataframe for NoRel incumbent/bound/timing information.  Note that this currently just captures NoRel's measure of elapsed time, which starts from the start of NoRel, not the start of the solve.
* Changes the `get_dataframe` return signature to:
```
summary, timelines = glt.get_dataframe(["run1/*.log", "run2/*.log"], timelines=True)
```
where timelines is a dict with three dataframes: `nodelog`, `rootlp`, and `norel`.  This seemed cleaner than extending the output tuple again, but am happy to change.
* Adds a simple test and tox config for testing compatible python versions.