### PR TITLE
Avoid coercing NewSolution to numeric

### DIFF
--- a/src/grblogtools/grblogtools.py
+++ b/src/grblogtools/grblogtools.py
@@ -839,7 +839,15 @@ def get_dataframe(logfiles, timelines=False, verbose=False, merged_logs=False, p
                         }
                     )
                 )
-                tl_ = tl_[tl_.columns].apply(pd.to_numeric, errors="coerce")
+                non_numeric_cols = set(tl_.columns).intersection({"NewSolution"})
+                numeric_cols = set(tl_.columns).difference(non_numeric_cols)
+                tl_ = pd.concat(
+                    [
+                        tl_[numeric_cols].apply(pd.to_numeric, errors="coerce"),
+                        tl_[non_numeric_cols],
+                    ],
+                    axis="columns",
+                )
                 _copy_keys(final, tl_)
 
                 tl = tl.append(tl_, ignore_index=True)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -30,3 +30,9 @@ def test_norel_timeline():
     assert (norel["BestBd"].min() - 8.00002e08) <= 1e05
     # Sometimes a bound isn't reported.
     assert norel["BestBd"].isnull().sum() == 1
+
+
+def test_newsolution_markers():
+    _, timelines = glt.get_dataframe(["data/912-glass4-1.log"], timelines=True)
+    new_solutions = timelines["nodelog"]["NewSolution"]
+    assert new_solutions.value_counts().to_dict() == {"H": 19, "*": 4}


### PR DESCRIPTION
Fixes an issue where symbolic flags for heuristic/node solutions
were lost in the conversion to dataframes.
