### PR TITLE
header-parser

### DIFF
--- a/src/grblogtools/header_parser.py
+++ b/src/grblogtools/header_parser.py
@@ -23,7 +23,7 @@ class HeaderLogParser:
         Note: All header log is captured in one line.
         """
         # The integer value representing the current parser status
-        self.flag = ParserFlag.UNKNOWN.value
+        self._flag = ParserFlag.UNKNOWN.value
         self._log = {}
 
     def get_flag(self, line: str) -> str:
@@ -35,7 +35,7 @@ class HeaderLogParser:
         Returns:
             str: The current parsing status.
         """
-        if self.flag == 0:
+        if self._flag == 0:
             for possible_start in HeaderLogParser.header_log_starts:
                 if match := possible_start.match(line):
                     # Populate the log as the header log is captured on the start line
@@ -44,19 +44,19 @@ class HeaderLogParser:
                         for sub_match, value in match.groupdict().items()
                     }
                     # Change the status to START
-                    self.flag = 1
+                    self._flag = 1
                     break
-        return ParserFlag(self.flag).name
+        return ParserFlag(self._flag).name
 
     def set_flag(self, status: str):
         """Set the current parsing status to the given status name."""
-        self.flag = ParserFlag[status].value
+        self._flag = ParserFlag[status].value
 
     def parse(self, line: str) -> str:
         """Return the current parsing status after parsing the given line."""
         # Set the flag to END
-        self.flag = 3
-        return ParserFlag(self.flag).name
+        self._flag = 3
+        return ParserFlag(self._flag).name
 
     def get_log(self) -> dict:
         """Return the current parsed log."""

--- a/src/grblogtools/header_parser.py
+++ b/src/grblogtools/header_parser.py
@@ -4,8 +4,8 @@ from grblogtools.helpers import ParserFlag
 
 
 class HeaderLogParser:
-    # Each can represent the start line for the header depending on how Gurobi
-    # is ran
+    # Each might represent the start of the header parser depending on how Gurobi
+    # is run
     header_log_starts = [
         re.compile(
             "Gurobi (?P<Version>\d{1,2}\.[^\s]+) \((?P<Platform>[^\)]+)\) logging started (?P<Time>.*)$"
@@ -20,14 +20,14 @@ class HeaderLogParser:
     def __init__(self):
         """Initialize the log parser for the header.
 
-        It is assumed that all the heard log is encapsulated in one line.
+        Note: All header log is captured in one line.
         """
-        # The integer value representing the current flag status
+        # The integer value representing the current parser status
         self.flag = ParserFlag.UNKNOWN.value
         self._log = {}
 
-    def get_flag(self, line: str) -> ParserFlag:
-        """Return the current parsing status of the header log.
+    def get_flag(self, line: str) -> str:
+        """Return the current status of the header parser.
 
         Args:
             line (str): A line in the log file.
@@ -37,19 +37,19 @@ class HeaderLogParser:
         """
         if self.flag == 0:
             for possible_start in HeaderLogParser.header_log_starts:
-                match = possible_start.match(line)
-                if match:
-                    # Populate the log as
+                if match := possible_start.match(line):
+                    # Populate the log as the header log is captured on the start line
                     self._log = {
                         sub_match: value
                         for sub_match, value in match.groupdict().items()
                     }
+                    # Change the status to START
                     self.flag = 1
                     break
         return ParserFlag(self.flag).name
 
     def set_flag(self, status: str):
-        """Set the current parsing status to the given status value."""
+        """Set the current parsing status to the given status name."""
         self.flag = ParserFlag[status].value
 
     def parse(self, line: str) -> str:
@@ -61,7 +61,3 @@ class HeaderLogParser:
     def get_log(self) -> dict:
         """Return the current parsed log."""
         return self._log
-
-
-if __name__ == "__main__":
-    hearder = HeaderLogParser()

--- a/src/grblogtools/header_parser.py
+++ b/src/grblogtools/header_parser.py
@@ -1,0 +1,67 @@
+import re
+
+from grblogtools.helpers import ParserFlag
+
+
+class HeaderLogParser:
+    # Each can represent the start line for the header depending on how Gurobi
+    # is ran
+    header_log_starts = [
+        re.compile(
+            "Gurobi (?P<Version>\d{1,2}\.[^\s]+) \((?P<Platform>[^\)]+)\) logging started (?P<Time>.*)$"
+        ),
+        re.compile("Logging started (?P<Time>.*)$"),
+        re.compile(
+            "Gurobi Compute Server Worker version (?P<Version>\d{1,2}\.[^\s]+) build (.*) \((?P<Platform>[^\)]+)\)$"
+        ),
+        re.compile("Compute Server job ID: (?P<JobID>.*)$"),
+    ]
+
+    def __init__(self):
+        """Initialize the log parser for the header.
+
+        It is assumed that all the heard log is encapsulated in one line.
+        """
+        # The integer value representing the current flag status
+        self.flag = ParserFlag.UNKNOWN.value
+        self._log = {}
+
+    def get_flag(self, line: str) -> ParserFlag:
+        """Return the current parsing status of the header log.
+
+        Args:
+            line (str): A line in the log file.
+
+        Returns:
+            str: The current parsing status.
+        """
+        if self.flag == 0:
+            for possible_start in HeaderLogParser.header_log_starts:
+                match = possible_start.match(line)
+                if match:
+                    # Populate the log as
+                    self._log = {
+                        sub_match: value
+                        for sub_match, value in match.groupdict().items()
+                    }
+                    self.flag = 1
+                    break
+        return ParserFlag(self.flag).name
+
+    def set_flag(self, status: str):
+        """Set the current parsing status to the given status value."""
+        self.flag = ParserFlag[status].value
+
+    def parse(self, line: str) -> str:
+        """Return the current parsing status after parsing the given line."""
+        # Set the flag to END
+        self.flag = 3
+        return ParserFlag(self.flag).name
+
+    def get_log(self) -> dict:
+        """Return the current parsed log."""
+        return self._log
+
+
+if __name__ == "__main__":
+    hearder = HeaderLogParser()

--- a/src/grblogtools/helpers.py
+++ b/src/grblogtools/helpers.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import re
+from enum import Enum
 from functools import lru_cache
 from functools import partial
 
@@ -89,3 +90,12 @@ def add_categorical_descriptions(summary):
             summary[column].map(PARAMETER_DESCRIPTIONS[column]).astype("category")
         )
     return summary
+
+
+class ParserFlag(Enum):
+    """Enumeration class representing various parsing stages."""
+
+    UNKNOWN = 0
+    START = 1
+    CONTINUE = 2
+    END = 3

--- a/src/grblogtools/helpers.py
+++ b/src/grblogtools/helpers.py
@@ -10,6 +10,15 @@ re_parameter_column = re.compile(r"(.*) \(Parameter\)")
 defaults_dir = pathlib.Path(__file__).parent.joinpath("defaults")
 
 
+class ParserFlag(Enum):
+    """Enumeration class representing different status of a parser."""
+
+    UNKNOWN = 0
+    START = 1
+    CONTINUE = 2
+    END = 3
+
+
 @lru_cache()
 def load_defaults(version):
     version_file = defaults_dir.joinpath(f"{version}.json")
@@ -90,12 +99,3 @@ def add_categorical_descriptions(summary):
             summary[column].map(PARAMETER_DESCRIPTIONS[column]).astype("category")
         )
     return summary
-
-
-class ParserFlag(Enum):
-    """Enumeration class representing various parsing stages."""
-
-    UNKNOWN = 0
-    START = 1
-    CONTINUE = 2
-    END = 3

--- a/tests/test_header_parser.py
+++ b/tests/test_header_parser.py
@@ -1,0 +1,70 @@
+from unittest import TestCase, main
+
+from grblogtools import get_dataframe
+from grblogtools.helpers import ParserFlag
+from grblogtools.header_parser import HeaderLogParser
+
+
+class TestHeaderLog(TestCase):
+    def setUp(self):
+        self._path_to_log = "data/912-Cuts0-glass4-0.log"
+        self._header_parser = HeaderLogParser()
+
+    def test_get_flag(self):
+        correct_start_lines = [
+            "Gurobi 9.1.2 (linux64, gurobi_cl) logging started Fri Jul 30 13:53:48 2021",
+            "Compute Server job ID: 7a51ec41-f72d-4b31-95ba-28407986eda3",
+            "Gurobi Compute Server Worker version 9.5.0 build v9.1.1rc0 (linux64)",
+            "Logging started Fri Jul 30 13:53:48 2021",
+            "Logging started",
+            "Gurobi 10.0.0 (linux64, gurobi_cl) logging started Fri Jul 30 13:53:48 2021",
+        ]
+
+        wrong_start_lines = [
+            "Gurobi 900.1.2 (linux64, gurobi_cl) logging started Fri Jul 30 13:53:48 2021",
+            "Compute Server job: 7a51ec41-f72d-4b31-95ba-28407986eda3",
+            "Gurobi Compute Server Worker version 9.5.0 build v9.1.1rc0 linux64",
+            "Logging starte",
+        ]
+        for line in correct_start_lines:
+            flag = self._header_parser.get_flag(line)
+            self.assertEqual(ParserFlag.START.name, flag)
+
+        # Reset the flag status
+        self._header_parser.set_flag(ParserFlag.UNKNOWN.name)
+
+        for line in wrong_start_lines:
+            flag = self._header_parser.get_flag(line)
+            self.assertEqual(ParserFlag.UNKNOWN.name, flag)
+
+    def test_parse(self):
+        # TODO: Remove the regression part associated with the get_dataframe() method
+        expected_log = {
+            "Version": "9.1.2",
+            "Platform": "linux64, gurobi_cl",
+            "Time": "Fri Jul 30 13:53:48 2021",
+        }
+        # Reset the flag status
+        self._header_parser.set_flag(ParserFlag.UNKNOWN.name)
+
+        df = get_dataframe([self._path_to_log])
+        with open(self._path_to_log, "r") as f:
+            lines = f.readlines()
+
+        current_parser = None
+        for line in lines:
+            if current_parser:
+                flag = current_parser.parse(line)
+
+            if self._header_parser.get_flag(line) == ParserFlag.START.name:
+                current_parser = self._header_parser
+
+        self.assertEqual(flag, ParserFlag.END.name)
+        header_log = self._header_parser.get_log()
+        for column, value in header_log.items():
+            self.assertEqual(df[column].values[0], value)
+            self.assertEqual(expected_log[column], value)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_header_parser.py
+++ b/tests/test_header_parser.py
@@ -38,7 +38,7 @@ class TestHeaderLog(TestCase):
             self.assertEqual(ParserFlag.UNKNOWN.name, flag)
 
     def test_parse(self):
-        # TODO: Remove the regression part associated with the get_dataframe() method
+        # TODO: Later remove the regression part associated with the get_dataframe() method
         expected_log = {
             "Version": "9.1.2",
             "Platform": "linux64, gurobi_cl",
@@ -47,17 +47,21 @@ class TestHeaderLog(TestCase):
         # Reset the flag status
         self._header_parser.set_flag(ParserFlag.UNKNOWN.name)
 
+        # Parse the header using the current get_dataframe() method
         df = get_dataframe([self._path_to_log])
-        with open(self._path_to_log, "r") as f:
-            lines = f.readlines()
 
         current_parser = None
-        for line in lines:
-            if current_parser:
-                flag = current_parser.parse(line)
+        with open(self._path_to_log, "r") as f:
+            while True:
+                try:
+                    line = next(f)
+                    if current_parser:
+                        flag = current_parser.parse(line)
 
-            if self._header_parser.get_flag(line) == ParserFlag.START.name:
-                current_parser = self._header_parser
+                    if self._header_parser.get_flag(line) == ParserFlag.START.name:
+                        current_parser = self._header_parser
+                except StopIteration:
+                    break
 
         self.assertEqual(flag, ParserFlag.END.name)
         header_log = self._header_parser.get_log()


### PR DESCRIPTION
This is a small PR to add the header parser. Specifically:
- The module `header_parser.py` is added to the `src/grblogtools` folder. Reading the current code conveyed to me that there is the underlying assumption that all header log information is captured in one line. I used the same assumption. Please let me know if this is not the right assumption and I am overlooking something.
- The module `test_header_parser.py` is added. It includes just two tests and running `pytest` from the parent folder picks up the tests. 
- The current `grblogtools.py` module is not refactored to reflect these changes. The plan is to do the presolve parser in the next PR (hopefully by the end of this week) and then see how the main code can change to include these changes.