### PR TITLE
Add postprocessing helpers for run labelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # CHANGELOG
 ## Unreleased
 ### Added
-- Parsing of deterministic work metric in nodelog, barrier, and simplex (#27).
+- Parsing of deterministic work metric in nodelog, barrier, and simplex (#27)
+- Add a ChangedParams summary column with parameters as a dictionary (#21)
 ### Fixed
-- Handle pandas warning related to groupy()
+- Handle pandas warning related to groupby()
 ### Changed
 ### Removed
 

--- a/src/grblogtools/parsers/header.py
+++ b/src/grblogtools/parsers/header.py
@@ -87,3 +87,7 @@ class HeaderParser:
     def get_parameters(self) -> dict:
         """Return all changed parameters detected in the header."""
         return self._parameters
+
+    def changed_params(self) -> int:
+        omit_params = {"Seed", "LogFile"}
+        return {k: v for k, v in self._parameters.items() if k not in omit_params}

--- a/src/grblogtools/parsers/single_log.py
+++ b/src/grblogtools/parsers/single_log.py
@@ -49,6 +49,7 @@ class SingleLogParser:
             quad_nonzeros=summary.get("NumQNZs", 0),
             quad_constrs=summary.get("NumQConstrs", 0),
         )
+        summary["ChangedParams"] = self.header_parser.changed_params()
         return summary
 
     def parse(self, line: str) -> bool:

--- a/tests/parsers/test_header.py
+++ b/tests/parsers/test_header.py
@@ -139,6 +139,16 @@ class TestHeader(TestCase):
         parse_lines(parser, ["Solving model misc07"])
         assert parser.get_summary() == {"ModelName": "misc07"}
 
+    def test_changed_params(self):
+        """Test non-default algorithm parameters (ignore seed and logfile)"""
+        parser = HeaderParser()
+        parser.parse("Set parameter Method to value 2")
+        parser.parse("Set parameter Threads to value 4")
+        parser.parse("Set parameter Seed to value 238476")
+        parser.parse("Set parameter LogFile to value log.log")
+        parser.parse("Set parameter TimeLimit to value 60")
+        assert parser.changed_params() == {"Method": 2, "Threads": 4, "TimeLimit": 60}
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Adds the run_label function in the postprocessing module which builds a label based on version and changed parameters.

Example usage:

```python
import grblogtools as glt
from grblogtools.postprocessing import run_label
summary = glt.get_dataframe(["data/*.log"])
run_label(summary)
```

Output is a Series, the same as current "Log" column for the glass4 examples, but built from the parameter values so does not rely on the file naming convention.

```
0     912-MIPFocus2-Presolve1
1     912-Cuts2-Heuristics0.1
2     912-Cuts2-Heuristics0.1
3     912-MIPFocus2-Presolve1
4     912-Cuts2-Heuristics0.1
               ...           
59    912-MIPFocus1-Presolve2
60                  912-Cuts1
61          912-Heuristics0.1
62          912-Heuristics0.0
63    912-Cuts2-Heuristics0.0
Length: 64, dtype: object 
```
