### PR TITLE
handle warning in newer pandas version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Parsing of deterministic work metric in nodelog, barrier, and simplex (#27).
 ### Fixed
+- Handle pandas warning related to groupy()
 ### Changed
 ### Removed
 

--- a/src/grblogtools/helpers.py
+++ b/src/grblogtools/helpers.py
@@ -26,7 +26,7 @@ def fill_default_parameters(summary):
         if re_parameter_column.match(column) and series.isnull().any()
     ]
     # TODO test cases where there are different versions involved
-    return summary.groupby("Version").apply(
+    return summary.groupby("Version", group_keys=False).apply(
         partial(fill_for_version, parameter_columns=parameter_columns)
     )
 
@@ -44,7 +44,7 @@ def fill_for_version_nosuffix(group):
 
 def fill_default_parameters_nosuffix(parameters):
     """Fill defaults for Version and parameter cols with no (Parameter) suffix."""
-    return parameters.groupby("Version").apply(fill_for_version_nosuffix)
+    return parameters.groupby("Version", group_keys=False).apply(fill_for_version_nosuffix)
 
 
 def add_categorical_descriptions(summary):

--- a/src/grblogtools/helpers.py
+++ b/src/grblogtools/helpers.py
@@ -44,7 +44,9 @@ def fill_for_version_nosuffix(group):
 
 def fill_default_parameters_nosuffix(parameters):
     """Fill defaults for Version and parameter cols with no (Parameter) suffix."""
-    return parameters.groupby("Version", group_keys=False).apply(fill_for_version_nosuffix)
+    return parameters.groupby("Version", group_keys=False).apply(
+        fill_for_version_nosuffix
+    )
 
 
 def add_categorical_descriptions(summary):


### PR DESCRIPTION
We currently get a warning with newer pandas versions:

```
grblogtools\helpers.py:47: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.
To preserve the previous behavior, use

	>>> .groupby(..., group_keys=False)

To adopt the future behavior and silence this warning, use 

	>>> .groupby(..., group_keys=True)
  return parameters.groupby("Version").apply(fill_for_version_nosuffix)
```

I added the suggested `group_keys=False` to the two affected calls of `groupby()` to avoid this warning.