### PR TITLE
Added sdist target for hatch in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ path = "src/gurobi_logtools/__init__.py"
 [tool.hatch.build.targets.wheel]
 packages = ["src/gurobi_logtools"]
 
+[tool.hatch.build.targets.sdist]
+packages = ["src/gurobi_logtools"]
+
 # Include the JSON parameter files that were listed in setup.cfg
 [tool.hatch.build]
 include = ["src/gurobi_logtools/parameters/data/*.json"]


### PR DESCRIPTION
Needed to add some extra info to the pyproject toml to account for the fact that the package is named gurobi-logtools but the package directory is gurobi_logtools.

See `https://github.com/astral-sh/uv/issues/7227` for example.

Without it we produce an empty wheel file when using `uv publish`
