### PR TITLE
avoid pandas deprecation warning

### DIFF
--- a/src/gurobi_logtools/api.py
+++ b/src/gurobi_logtools/api.py
@@ -60,12 +60,16 @@ class FullLogParseResult:
             else:
                 raise ValueError(f"Unknown section '{section}'")
 
-            progress.append(
-                pd.DataFrame(log).assign(LogFilePath=logfile, LogNumber=lognumber),
-            )
+            if log:
+                progress.append(
+                    pd.DataFrame(log).assign(LogFilePath=logfile, LogNumber=lognumber),
+                )
+
+        if not progress:
+            return pd.DataFrame()
 
         return pd.merge(
-            left=pd.concat(progress),
+            left=pd.concat([df.dropna(axis=1, how="all") for df in progress]),
             right=self.common_log_data(),
             how="left",
             on=["LogFilePath", "LogNumber"],


### PR DESCRIPTION
### Checklist

- [x] closes #67
- [x] tests passed
- [x] all linting tests pass

### Description:
Avoids pandas deprecation warning:
`FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.`
    