### PR TITLE
[GH122] bugfix for NODE_LIMIT column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 - Dropped support for Python 3.9
 ### Added
+- Bugfix for NODE_LIMIT column appearing in summary dataframe (#GH122)
 - Added support for parsing finer details in multi-objective logs (#GH36)
 - Added the `warnings_action` parameter to `gurobi_logtools.parse` (#GH88)
 - NumConVars, NumIntVars and NumBinVars are added to capture variable types in original model (#GH89)

--- a/src/gurobi_logtools/parsers/termination.py
+++ b/src/gurobi_logtools/parsers/termination.py
@@ -39,6 +39,7 @@ class TerminationParser(Parser):
     status = [
         "OPTIMAL",
         "TIME_LIMIT",
+        "NODE_LIMIT",
         "ITERATION_LIMIT",
         "INF_OR_UNBD",
         "UNBOUNDED",


### PR DESCRIPTION
### Checklist

- [x] closes #122 
- [x] all linting tests pass
- [x] changelog entry

### Description:

If solve finished via node limit termination we were adding a NODE_LIMIT column to the summary dataframe.  This fixes that.