### PR TITLE
[GH126] added multiobjective quality stats parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 - Dropped support for Python 3.9
 ### Added
+- Added parsing for quality stats that may appear at end of multiobjective log (#GH126)
 - Added recognition for SUBOPTIMAL, LOCALLY_OPTIMAL and LOCALLY_INFEASIBLE statuses (#GH124)
 - Bugfix for NODE_LIMIT column appearing in summary dataframe (#GH122)
 - Added support for parsing finer details in multi-objective logs (#GH36)

--- a/src/gurobi_logtools/parsers/multiobj.py
+++ b/src/gurobi_logtools/parsers/multiobj.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from gurobi_logtools.parsers.presolve import PresolveParser
+from gurobi_logtools.parsers.quality import QualityParser
 from gurobi_logtools.parsers.single_log_base import SingleLogBase
 from gurobi_logtools.parsers.util import (
     float_pattern,
@@ -78,10 +79,11 @@ class MultiObjParser(Parser):
         self.parser: Parser = self.initial_presolve_parser
         self.subsequent: ObjNLogParser = self._ObjNLogParser()
         self.objn_parsers = []
+        self.quality_parser = QualityParser()
 
     def parse(self, line: str) -> ParseResult:
-        if self._terminated:
-            return ParseResult(matched=False)
+        # if self._terminated:
+        # return ParseResult(matched=False)
 
         if not self._started:
             for pattern in self.start_patterns:
@@ -102,6 +104,9 @@ class MultiObjParser(Parser):
             self._summary.update(parse_result)
             self._terminated = True
             return ParseResult(parse_result)
+
+        if parse_result := self.quality_parser.parse(line):
+            return parse_result
 
         if not (parse_result := self.parser.parse(line)):
             assert not self.subsequent.started
@@ -125,6 +130,7 @@ class MultiObjParser(Parser):
         return {
             **self._summary,
             **self.initial_presolve_parser.get_summary(add_model_type=False),
+            **self.quality_parser.get_summary(),
         }
 
     def get_objn_summaries(self):

--- a/tests/parsers/test_multiobjective.py
+++ b/tests/parsers/test_multiobjective.py
@@ -97,6 +97,12 @@ Best objective 5.989536000000e+06, best bound 5.691475302964e+06, gap 4.9764%
 ---------------------------------------------------------------------------
 Multi-objectives: stopped in 10.01 seconds (15.70 work units), solution count 10
 Time Limit reached
+
+Solution quality statistics for unnamed model:
+  Maximum violation:
+    Bound       : 0.00000000e+00
+    Constraint  : 5.00000000e-09 (demand_fraction_met_419238_----_CS_2)
+    Integrality : 7.13275204e-07 (y_407382_----_6_1)
 """
 
     parser = MultiObjParser()
@@ -296,3 +302,11 @@ def test_summary(test_data_parser):
         },
     ]
     assert test_data_parser.get_objn_summaries() == expected
+
+
+def test_multiobj_quality_stats(test_data_parser):
+    # GH126
+    summary = test_data_parser.get_summary()
+    assert summary["BoundVio"] == 0
+    assert summary["ConstrVio"] == 5.00000000e-09
+    assert summary["IntVio"] == 7.13275204e-07


### PR DESCRIPTION
### Checklist

- [x] closes #126 
- [x] tests added
- [x] tests passed
- [x] all linting tests pass
- [x] example notebook updated (if relevant)
- [x] changelog entry

### Description:
Adds parsing for solution quality stats in multiobjective logs (produced with the -q option for gurobi_cl)
